### PR TITLE
Fix typo

### DIFF
--- a/doc/pg_timestamp.html
+++ b/doc/pg_timestamp.html
@@ -39,7 +39,7 @@ following 19byte format:
 
 <h2>Installation</h2>
 <p>
-Installation sequence is shown below. Parmission for installed directories are 
+Installation sequence is shown below. Permissions for installed directories are 
 given correctly.
 </p>
 <pre><code>


### PR DESCRIPTION
Clearly a typo, although I'm not entirely sure what the sentence is trying to communicate because the code snippet doesn't including any `chmod`/`chown` commands.