### PR TITLE
Fix unsupported PG version number.

### DIFF
--- a/lib/pg_btree.c
+++ b/lib/pg_btree.c
@@ -49,7 +49,7 @@ static void unused_bt_leafbuild(BTSpool *, BTSpool *);
 #define _bt_spool			unused_bt_spool
 #define _bt_leafbuild		unused_bt_leafbuild
 
-#if PG_VERSION_NUM >= 90700
+#if PG_VERSION_NUM >= 100000
 #error unsupported PostgreSQL version
 #elif PG_VERSION_NUM >= 90600
 #include "nbtree/nbtsort-9.6.c"

--- a/lib/pgut/pgut-be.h
+++ b/lib/pgut/pgut-be.h
@@ -178,7 +178,7 @@ extern Datum ExecFetchSlotTupleDatum(TupleTableSlot *slot);
 #elif PG_VERSION_NUM < 90500
 #define RelationSetNewRelfilenode(rel, xid) \
 	RelationSetNewRelfilenode((rel), (xid), (xid))
-#elif PG_VERSION_NUM < 90700
+#elif PG_VERSION_NUM < 100000
 #define RelationSetNewRelfilenode(rel, xid) \
 	RelationSetNewRelfilenode((rel), (rel->rd_rel->relpersistence), \
 		(xid), (xid))


### PR DESCRIPTION
The new version number is 10, not 9.7.

Note: this is fine in the master branch