### PR TITLE
fix "function  is not unique" error

### DIFF
--- a/lib/pg_strutil.c
+++ b/lib/pg_strutil.c
@@ -565,6 +565,8 @@ ParseFunction(const char *value, bool argistype)
 		{
 			find = func_select_candidate(nargs, ret.argtypes,
 										 current_candidates);
+			if (find)
+				ncandidates = 1;
 		}
 	}
 	else if (nargs > 0)


### PR DESCRIPTION
if we find a candidates, ncandidates should be assigned to 1. Otherwise ncandidates may great than 1.