### PR TITLE
Patch for respond to vulnerabilities of CVE-2018-1058(search_path).

### DIFF
--- a/bin/expected/load_bin.out
+++ b/bin/expected/load_bin.out
@@ -2,27 +2,27 @@ TRUNCATE customer;
 \! pg_bulkload -d contrib_regression data/bin1.ctl -i infile_logfile -l infile_logfile -P pbfile -u dbfile
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  INPUT, PARSE_BADFILE, DUPLICATE_BADFILE and LOGFILE cannot set the same file name.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/bin1.ctl -i infile_pbfile -l logfile -P infile_pbfile -u dbfile
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  INPUT, PARSE_BADFILE, DUPLICATE_BADFILE and LOGFILE cannot set the same file name.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/bin1.ctl -i infile_dbfile -l logfile -P pbfile -u infile_dbfile
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  INPUT, PARSE_BADFILE, DUPLICATE_BADFILE and LOGFILE cannot set the same file name.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/bin1.ctl -i infile -l logfile_pbfile -P logfile_pbfile -u dbfile
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  INPUT, PARSE_BADFILE, DUPLICATE_BADFILE and LOGFILE cannot set the same file name.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/bin1.ctl -i infile -l logfile_dbfile -P pbfile -u logfile_dbfile
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  INPUT, PARSE_BADFILE, DUPLICATE_BADFILE and LOGFILE cannot set the same file name.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/bin1.ctl -i infile -l logfile -P pbfile_dbfile -u pbfile_dbfile
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  INPUT, PARSE_BADFILE, DUPLICATE_BADFILE and LOGFILE cannot set the same file name.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 TRUNCATE customer;
 SET enable_seqscan = off;
 SET enable_indexscan = on;
@@ -556,7 +556,7 @@ NOTICE: BULK LOAD START
 WARNING:  Parse error Record 1: Input Record 2: Rejected - column 3. invalid input syntax for integer: "172270229a"
 WARNING:  Maximum parse error count exceeded - 1 error(s) found in input file
 ERROR: query failed: ERROR:  integer out of range
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/bin6.log
 
 pg_bulkload 3.1.14 on <TIMESTAMP>
@@ -987,27 +987,27 @@ CPU <TIME>s/<TIME>u sec elapsed <TIME> sec
 \! echo -n "" | pg_bulkload -d contrib_regression data/bin5.ctl -l results/bin_error.log -o "COL=SHORT NULLIF abcg"
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  NULLIF argument must be '...' or hex digits
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! echo -n "" | pg_bulkload -d contrib_regression data/bin5.ctl -l results/bin_error.log -o PRESERVE_BLANKS=NO -o "COL=10 aaaa"
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  invalid input syntax for integer: "10 aaaa"
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! echo -n "" | pg_bulkload -d contrib_regression data/bin5.ctl -l results/bin_error.log -o "COL=SHORT (2) NULLIF abcd aaaa"
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  NULLIF argument must be '...' or hex digits
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! echo -n "" | pg_bulkload -d contrib_regression data/bin5.ctl -l results/bin_error.log -o "COL=SHORT NULLIF abcd aaaa"
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  NULLIF argument must be '...' or hex digits
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! echo -n "" | pg_bulkload -d contrib_regression data/bin5.ctl -l results/bin_error.log -o "COL=SHORT (2) aaaa"
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  syntax error at or near "aaaa" : SHORT (2) aaaa
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! echo -n "" | pg_bulkload -d contrib_regression data/bin5.ctl -l results/bin_error.log -o "COL=SHORT aaaa"
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  invalid typename : SHORT aaaa
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 -- load from stdin
 \! pg_bulkload -d contrib_regression data/bin1.ctl -i Stdin -l results/bin12.log -P results/bin12.prs -u results/bin12.dup -o TRUNCATE=YES -o ENCODING=SQLASCII < data/data1.bin
 NOTICE: BULK LOAD START

--- a/bin/expected/load_check.out
+++ b/bin/expected/load_check.out
@@ -78,7 +78,7 @@ SELECT * FROM target ORDER BY id;
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  could not create unique index "target_pkey"
 DETAIL:  Key (id)=(1) is duplicated.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/check2.log
 
 pg_bulkload 3.1.14 on <TIMESTAMP>

--- a/bin/expected/load_check_1.out
+++ b/bin/expected/load_check_1.out
@@ -78,7 +78,7 @@ SELECT * FROM target ORDER BY id;
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  could not create unique index "target_pkey"
 DETAIL:  Table contains duplicated values.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/check2.log
 
 pg_bulkload 3.1.13 on <TIMESTAMP>

--- a/bin/expected/load_csv.out
+++ b/bin/expected/load_csv.out
@@ -148,7 +148,7 @@ SELECT * FROM customer ORDER BY c_id;
 \! pg_bulkload -d contrib_regression data/csv1.ctl -i data/data2.csv -l results/csv2.log -P results/csv2.prs -u results/csv2.dup -o "PARSE_ERRORS=50"
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  Maximum duplicate error count exceeded
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/csv2.log
 
 pg_bulkload 3.1.14 on <TIMESTAMP>
@@ -430,7 +430,7 @@ NOTICE: BULK LOAD START
 WARNING:  Parse error Record 1: Input Record 2: Rejected - column 3. invalid input syntax for integer: "int4"
 WARNING:  Maximum parse error count exceeded - 1 error(s) found in input file
 ERROR: query failed: ERROR:  integer out of range
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/csv6.log
 
 pg_bulkload 3.1.14 on <TIMESTAMP>

--- a/bin/expected/load_csv_1.out
+++ b/bin/expected/load_csv_1.out
@@ -148,7 +148,7 @@ SELECT * FROM customer ORDER BY c_id;
 \! pg_bulkload -d contrib_regression data/csv1.ctl -i data/data2.csv -l results/csv2.log -P results/csv2.prs -u results/csv2.dup -o "PARSE_ERRORS=50"
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  Maximum duplicate error count exceeded
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/csv2.log
 
 pg_bulkload 3.1.13 on <TIMESTAMP>
@@ -430,7 +430,7 @@ NOTICE: BULK LOAD START
 WARNING:  Parse error Record 1: Input Record 2: Rejected - column 3. invalid input syntax for integer: "int4"
 WARNING:  Maximum parse error count exceeded - 1 error(s) found in input file
 ERROR: query failed: ERROR:  integer out of range
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/csv6.log
 
 pg_bulkload 3.1.13 on <TIMESTAMP>

--- a/bin/expected/load_filter.out
+++ b/bin/expected/load_filter.out
@@ -31,87 +31,87 @@ INSERT INTO target VALUES(1, 'dummy', 1);
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=variadic_f(int, text)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  filter function does not support a valiadic function variadic_f
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=overload_f'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function overload_f() is not unique
 HINT:  Could not choose a best candidate function.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=using_out_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function using_out_f() does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=using_out_f(int4, int4, text)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function using_out_f(integer, integer, text) does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data7.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=outarg_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  could not create unique index "target_pkey"
 DETAIL:  Key (id)=(1) is duplicated.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=setof_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  filter function must not return set
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=using_out_f(int4, int4, int4)' -o FORCE_NOT_NULL=id
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  cannot use FILTER with FORCE_NOT_NULL
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data7.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=type_mismatch_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function return row and target table row do not match
 DETAIL:  Returned row contains 2 attribute(s), but target table expects 3.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=no_create_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function no_create_f() does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data7.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=rec_mismatch_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  could not create unique index "target_pkey"
 DETAIL:  Key (id)=(1) is duplicated.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 -- FILTER option error
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER="f1'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: "f1
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=  (int4)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error:   (int4)
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER="f1" int4, int4, text)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: "f1" int4, int4, text)
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  functions cannot have more than 100 arguments
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(int4, int4, text)    aaa'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: f1(int4, int4, text)    aaa
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(numeric((1,2)))'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: f1(numeric((1,2)))
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(numeric(1, 2) (1, 2))'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: f1(numeric(1, 2) (1, 2))
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(    , text)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: f1(    , text)
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(double)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  type "double" does not exist
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 SET enable_seqscan = on;
 SET enable_indexscan = off;
 SET enable_bitmapscan = off;

--- a/bin/expected/load_filter_2.out
+++ b/bin/expected/load_filter_2.out
@@ -31,87 +31,87 @@ INSERT INTO target VALUES(1, 'dummy', 1);
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=variadic_f(int, text)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  filter function does not support a valiadic function variadic_f
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=overload_f'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function overload_f() is not unique
 HINT:  Could not choose a best candidate function.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=using_out_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function using_out_f() does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=using_out_f(int4, int4, text)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function using_out_f(integer, integer, text) does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data7.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=outarg_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  could not create unique index "target_pkey"
 DETAIL:  Table contains duplicated values.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=setof_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  filter function must not return set
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=using_out_f(int4, int4, int4)' -o FORCE_NOT_NULL=id
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  cannot use FILTER with FORCE_NOT_NULL
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data7.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=type_mismatch_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function return row and target table row do not match
 DETAIL:  Returned row contains 2 attribute(s), but target table expects 3.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=no_create_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function no_create_f() does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data7.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=rec_mismatch_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  could not create unique index "target_pkey"
 DETAIL:  Table contains duplicated values.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 -- FILTER option error
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER="f1'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: "f1
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=  (int4)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error:   (int4)
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER="f1" int4, int4, text)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: "f1" int4, int4, text)
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  functions cannot have more than 100 arguments
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(int4, int4, text)    aaa'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: f1(int4, int4, text)    aaa
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(numeric((1,2)))'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: f1(numeric((1,2)))
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(numeric(1, 2) (1, 2))'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: f1(numeric(1, 2) (1, 2))
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(    , text)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: f1(    , text)
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(double)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  type "double" does not exist
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 SET enable_seqscan = on;
 SET enable_indexscan = off;
 SET enable_bitmapscan = off;

--- a/bin/expected/load_filter_3.out
+++ b/bin/expected/load_filter_3.out
@@ -31,87 +31,87 @@ INSERT INTO target VALUES(1, 'dummy', 1);
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=variadic_f(int, text)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  filter function does not support a valiadic function variadic_f
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=overload_f'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function overload_f() is not unique
 HINT:  Could not choose a best candidate function.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=using_out_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function using_out_f() does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=using_out_f(int4, int4, text)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function using_out_f(integer, integer, text) does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data7.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=outarg_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  could not create unique index "target_pkey"
 DETAIL:  Table contains duplicated values.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=setof_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  filter function must not return set
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=using_out_f(int4, int4, int4)' -o FORCE_NOT_NULL=id
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  cannot use FILTER with FORCE_NOT_NULL
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data7.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=type_mismatch_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function return row and target table row do not match
 DETAIL:  Returned row contains 2 attribute(s), but target table expects 3.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=no_create_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function no_create_f() does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data7.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=rec_mismatch_f()'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  could not create unique index "target_pkey"
 DETAIL:  Table contains duplicated values.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 -- FILTER option error
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER="f1'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: "f1
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=  (int4)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error:   (int4)
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER="f1" int4, int4, text)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: "f1" int4, int4, text)
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4,int4)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  functions cannot have more than 100 arguments
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(int4, int4, text)    aaa'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: f1(int4, int4, text)    aaa
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(numeric((1,2)))'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: f1(numeric((1,2)))
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(numeric(1, 2) (1, 2))'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: f1(numeric(1, 2) (1, 2))
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(    , text)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: f1(    , text)
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/csv4.ctl -i data/data6.csv -l results/filter_e.log -P results/filter_e1.prs -u results/filter_e1.dup -o 'FILTER=f1(double)'
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  type "double" does not exist
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 SET enable_seqscan = on;
 SET enable_indexscan = off;
 SET enable_bitmapscan = off;

--- a/bin/expected/load_function.out
+++ b/bin/expected/load_function.out
@@ -12,45 +12,45 @@ $$ LANGUAGE SQL;
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function public.load_function(integer, integer, unknown) does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A''','B')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function public.load_function1(integer, integer, unknown, unknown) does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1('A',5,'A''')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  invalid input syntax for integer: "A"
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A'')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: public.load_function1(1,5,'A'')
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A'''" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: public.load_function1(1,5,'A'''
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5 'A''')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: public.load_function1(1,5 'A''')
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A''',1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  functions cannot have more than 100 arguments
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,A)" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  invalid input syntax for type numeric: "A"
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,--5,'A''')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: public.load_function1(1,--5,'A''')
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=pg_catalog.to_char('1','0')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function pg_catalog.to_char(unknown, unknown) is not unique
 HINT:  Could not choose a best candidate function.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A''')" -l results/function1.log -P results/function1.prs -u results/function1.dup -o LOAD=3
 NOTICE: BULK LOAD START
 NOTICE: BULK LOAD END
@@ -873,7 +873,7 @@ SELECT :LOAD1 < :LOAD10000 AS "LOAD1 is fast";
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  could not create unique index "customer_pkey"
 DETAIL:  Key (c_id, c_w_id, c_d_id)=(1, 0, 216) is duplicated.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/function13.log
 
 pg_bulkload 3.1.14 on <TIMESTAMP>
@@ -904,7 +904,7 @@ TRUNCATE customer;
 \! pg_bulkload -d contrib_regression data/csv3.ctl -i results/function9.dup -o "SKIP=2" -l results/function14.log -P results/function14.prs -u results/function14.dup -o "ON_DUPLICATE_KEEP=OLD" -o "DUPLICATE_ERRORS=1"
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  Maximum duplicate error count exceeded
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/function14.log
 
 pg_bulkload 3.1.14 on <TIMESTAMP>

--- a/bin/expected/load_function_1.out
+++ b/bin/expected/load_function_1.out
@@ -12,45 +12,45 @@ $$ LANGUAGE SQL;
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function public.load_function(integer, integer, unknown) does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A''','B')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function public.load_function1(integer, integer, unknown, unknown) does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1('A',5,'A''')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  invalid input syntax for integer: "A"
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A'')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: public.load_function1(1,5,'A'')
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A'''" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: public.load_function1(1,5,'A'''
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5 'A''')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: public.load_function1(1,5 'A''')
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A''',1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  functions cannot have more than 100 arguments
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,A)" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  invalid input syntax for type numeric: "A"
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,--5,'A''')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: public.load_function1(1,--5,'A''')
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=pg_catalog.to_char('1','0')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function pg_catalog.to_char(unknown, unknown) is not unique
 HINT:  Could not choose a best candidate function.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A''')" -l results/function1.log -P results/function1.prs -u results/function1.dup -o LOAD=3
 NOTICE: BULK LOAD START
 NOTICE: BULK LOAD END
@@ -873,7 +873,7 @@ SELECT :LOAD1 < :LOAD10000 AS "LOAD1 is fast";
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  could not create unique index "customer_pkey"
 DETAIL:  Table contains duplicated values.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/function13.log
 
 pg_bulkload 3.1.13 on <TIMESTAMP>
@@ -904,7 +904,7 @@ TRUNCATE customer;
 \! pg_bulkload -d contrib_regression data/csv3.ctl -i results/function9.dup -o "SKIP=2" -l results/function14.log -P results/function14.prs -u results/function14.dup -o "ON_DUPLICATE_KEEP=OLD" -o "DUPLICATE_ERRORS=1"
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  Maximum duplicate error count exceeded
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/function14.log
 
 pg_bulkload 3.1.13 on <TIMESTAMP>

--- a/bin/expected/load_function_2.out
+++ b/bin/expected/load_function_2.out
@@ -12,49 +12,49 @@ $$ LANGUAGE SQL;
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function public.load_function(integer, integer, unknown) does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A''','B')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function public.load_function1(integer, integer, unknown, unknown) does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1('A',5,'A''')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  invalid input syntax for integer: "A"
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A'')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: public.load_function1(1,5,'A'')
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A'''" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: public.load_function1(1,5,'A'''
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5 'A''')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: public.load_function1(1,5 'A''')
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A''',1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  functions cannot have more than 100 arguments
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,A)" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  invalid input syntax for type numeric: "A"
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,--5,'A''')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: public.load_function1(1,--5,'A''')
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=pg_catalog.to_char('1','0')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function pg_catalog.to_char(unknown, unknown) is not unique
 HINT:  Could not choose a best candidate function.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=pg_catalog.lower('A')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function must return set
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A''')" -l results/function1.log -P results/function1.prs -u results/function1.dup -o LOAD=3
 NOTICE: BULK LOAD START
 NOTICE: BULK LOAD END
@@ -877,7 +877,7 @@ SELECT :LOAD1 < :LOAD10000 AS "LOAD1 is fast";
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  could not create unique index "customer_pkey"
 DETAIL:  Key (c_id, c_w_id, c_d_id)=(1, 0, 216) is duplicated.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/function13.log
 
 pg_bulkload 3.1.12 on <TIMESTAMP>
@@ -908,7 +908,7 @@ TRUNCATE customer;
 \! pg_bulkload -d contrib_regression data/csv3.ctl -i results/function9.dup -o "SKIP=2" -l results/function14.log -P results/function14.prs -u results/function14.dup -o "ON_DUPLICATE_KEEP=OLD" -o "DUPLICATE_ERRORS=1"
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  Maximum duplicate error count exceeded
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/function14.log
 
 pg_bulkload 3.1.12 on <TIMESTAMP>

--- a/bin/expected/load_function_3.out
+++ b/bin/expected/load_function_3.out
@@ -12,49 +12,49 @@ $$ LANGUAGE SQL;
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function public.load_function(integer, integer, unknown) does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A''','B')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function public.load_function1(integer, integer, unknown, unknown) does not exist
 HINT:  No function matches the given name and argument types.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1('A',5,'A''')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  invalid input syntax for integer: "A"
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A'')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: public.load_function1(1,5,'A'')
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A'''" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: public.load_function1(1,5,'A'''
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5 'A''')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: public.load_function1(1,5 'A''')
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A''',1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  functions cannot have more than 100 arguments
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,A)" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  invalid input syntax for type numeric: "A"
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,--5,'A''')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function call syntax error: public.load_function1(1,--5,'A''')
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=pg_catalog.to_char('1','0')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function pg_catalog.to_char(unknown, unknown) is not unique
 HINT:  Could not choose a best candidate function.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=pg_catalog.lower('A')" -l results/function_e.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  function must return set
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/function1.ctl -o "INFILE=public.load_function1(1,5,'A''')" -l results/function1.log -P results/function1.prs -u results/function1.dup -o LOAD=3
 NOTICE: BULK LOAD START
 NOTICE: BULK LOAD END
@@ -877,7 +877,7 @@ SELECT :LOAD1 < :LOAD10000 AS "LOAD1 is fast";
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  could not create unique index "customer_pkey"
 DETAIL:  Table contains duplicated values.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/function13.log
 
 pg_bulkload 3.1.12 on <TIMESTAMP>
@@ -908,7 +908,7 @@ TRUNCATE customer;
 \! pg_bulkload -d contrib_regression data/csv3.ctl -i results/function9.dup -o "SKIP=2" -l results/function14.log -P results/function14.prs -u results/function14.dup -o "ON_DUPLICATE_KEEP=OLD" -o "DUPLICATE_ERRORS=1"
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  Maximum duplicate error count exceeded
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/function14.log
 
 pg_bulkload 3.1.12 on <TIMESTAMP>

--- a/bin/expected/load_parallel.out
+++ b/bin/expected/load_parallel.out
@@ -78,7 +78,7 @@ SELECT * FROM customer ORDER BY c_id;
 \! pg_bulkload -d contrib_regression data/csv1.ctl -i data/data2.csv -o "MULTI_PROCESS=YES" -l results/parallel2.log -P results/parallel2.prs -u results/parallel2.dup -o "PARSE_ERRORS=50"
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  Maximum duplicate error count exceeded
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/parallel2.log
 
 pg_bulkload 3.1.14 on <TIMESTAMP>
@@ -217,7 +217,7 @@ SELECT * FROM customer ORDER BY c_id;
 \! pg_bulkload -d contrib_regression data/csv1.ctl -i data/data2.csv -o "MULTI_PROCESS=YES" -o "WRITER=DIRECT" -o "PARSE_ERRORS=0" -l results/parallel4.log -P results/parallel4.prs -u results/parallel4.dup
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  Maximum duplicate error count exceeded
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! awk -f data/adjust.awk results/parallel4.log
 
 pg_bulkload 3.1.14 on <TIMESTAMP>
@@ -359,7 +359,7 @@ CREATE INDEX bar_c ON public.bar(c);
 \! pg_bulkload -d contrib_regression -i results/size_over.csv -O public.bar -o MULTI_PROCESS=YES -o TRUNCATE=YES -l results/parallel7.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  write length is too large
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 SET enable_seqscan = on;
 SET enable_indexscan = off;
 SET enable_bitmapscan = off;

--- a/bin/expected/write_bin.out
+++ b/bin/expected/write_bin.out
@@ -22,54 +22,54 @@ $$ LANGUAGE SQL;
 \! pg_bulkload -d contrib_regression data/binout1.ctl -i data/binout1.csv -l results/binout1.log -P results/binout1.prs -o TYPE=CSV -O results/binout1.bin -o TRUNCATE=YES
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  invalid keyword "TRUNCATE"
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! touch results/binout1.bin results/binout1.bin.ctl
 \! pg_bulkload -d contrib_regression data/binout1.ctl -i data/binout1.csv -l results/binout1.log -P results/binout1.prs -o TYPE=CSV -O results/binout1.bin
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  could not open binary output file: File exists
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! rm results/binout1.bin
 \! pg_bulkload -d contrib_regression data/binout1.ctl -i data/binout1.csv -l results/binout1.log -P results/binout1.prs -o TYPE=CSV -O results/binout1.bin
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  could not open sample control file: File exists
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! rm results/binout1.bin.ctl
 \! pg_bulkload -d contrib_regression data/binout1.ctl -i data/binout1.csv -l results/binout1.log -P results/binout1.prs -o TYPE=CSV -O results/binout1.bin -u results/binout1.dup
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  invalid keyword "duplicate-badfile"
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/binout1.ctl -i data/binout1.csv -l results/binout1.log -P results/binout1.prs -o TYPE=CSV -O results/binout1.bin -o DUPLICATE_BADFILE=/tmp/binout1.dup
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  invalid keyword "DUPLICATE_BADFILE"
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/binout1.ctl -i data/binout1.csv -l results/binout1.log -P results/binout1.prs -o TYPE=CSV -O results/binout1.bin -o DUPLICATE_ERRORS=0
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  invalid keyword "DUPLICATE_ERRORS"
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/binout1.ctl -i data/binout1.csv -l results/binout1.log -P results/binout1.prs -o TYPE=CSV -O results/binout1.bin -o ON_DUPLICATE_KEEP=NEW
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  invalid keyword "ON_DUPLICATE_KEEP"
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/binout1.ctl -i data/binout1.csv -l results/binout1.log -P results/binout1.prs -o TYPE=CSV -O results/binout1.bin -o "OUT_COL=CHAR(100+10)"
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  TYPE argument must be ( L )
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/binout1.ctl -i data/binout1.csv -l results/binout1.log -P results/binout1.prs -o TYPE=CSV -O results/binout1.bin -o "OUT_COL=CHAR(100:110)"
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  TYPE argument must be ( L )
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/binout1.ctl -i data/binout1.csv -l results/binout1.log -P results/binout1.prs -o TYPE=CSV -O data/binout1.csv
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  INPUT, PARSE_BADFILE, OUTPUT, LOGFILE and sample control file cannot set the same file name.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/binout1.ctl -i data/binout1.csv -l results/binout1.log -P results/binout1.prs -o TYPE=CSV -O results/binout1.log
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  INPUT, PARSE_BADFILE, OUTPUT, LOGFILE and sample control file cannot set the same file name.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 \! pg_bulkload -d contrib_regression data/binout1.ctl -i data/binout1.csv -l results/binout1.log -P results/binout1.prs -o TYPE=CSV -O results/binout1.prs
 NOTICE: BULK LOAD START
 ERROR: query failed: ERROR:  INPUT, PARSE_BADFILE, OUTPUT, LOGFILE and sample control file cannot set the same file name.
-DETAIL: query was: SELECT * FROM pg_bulkload($1)
+DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
 /* normal case */
 \! pg_bulkload -d contrib_regression data/binout1.ctl -i data/binout1.csv -l results/binout1.log -P results/binout1.prs -o TYPE=CSV -O results/binout1.bin
 NOTICE: BULK LOAD START

--- a/bin/pg_bulkload.c
+++ b/bin/pg_bulkload.c
@@ -308,7 +308,7 @@ LoaderLoadMain(List *options)
 
 	command("BEGIN", 0, NULL);
 	params[0] = buf.data;
-	res = execute("SELECT * FROM pg_bulkload($1)", 1, params);
+	res = execute("SELECT * FROM pgbulkload.pg_bulkload($1)", 1, params);
 	if (PQresultStatus(res) == PGRES_COPY_IN)
 	{
 		PQclear(res);

--- a/bin/pgut/pgut.c
+++ b/bin/pgut/pgut.c
@@ -478,6 +478,12 @@ pgut_connect(const char *info, YesNo prompt, int elevel)
 				termStringInfo(&add_pass);
 			free(passwd);
 
+			/* Set the search_path to value of pg_catalog, pg_temp, public 
+			 * before connecting to Postgres 
+			 * by respond to vulnerabilities of CVE-2018-1058.
+			 */
+			pgut_command(conn, "SET search_path TO pg_catalog, pg_temp, public", 0, NULL);
+
 			return conn;
 		}
 

--- a/lib/pg_bulkload--1.0.sql
+++ b/lib/pg_bulkload--1.0.sql
@@ -3,8 +3,10 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION pg_bulkload" to load this file. \quit
 
+CREATE SCHEMA pgbulkload;
+
 -- Adjust this setting to control where the objects get created.
-CREATE FUNCTION pg_bulkload(
+CREATE FUNCTION pgbulkload.pg_bulkload(
 	IN options text[],
 	OUT skip bigint,
 	OUT count bigint,

--- a/lib/pg_bulkload--unpackaged--1.0.sql
+++ b/lib/pg_bulkload--unpackaged--1.0.sql
@@ -3,4 +3,4 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION pg_bulkload" to load this file. \quit
 
-ALTER EXTENSION pg_bulkload ADD FUNCTION pg_bulkload(text[]);
+ALTER EXTENSION pg_bulkload ADD FUNCTION pgbulkload.pg_bulkload(text[]);

--- a/lib/pg_bulkload.control
+++ b/lib/pg_bulkload.control
@@ -3,4 +3,3 @@ comment = 'pg_bulkload is a high speed data loading utility for PostgreSQL'
 default_version = '1.0'
 module_pathname = '$libdir/pg_bulkload'
 relocatable = false
-schema = public

--- a/lib/pg_bulkload.sql.in
+++ b/lib/pg_bulkload.sql.in
@@ -5,11 +5,11 @@
  */
 
 -- Adjust this setting to control where the objects get created.
-SET search_path = public;
-
 BEGIN;
 
-CREATE FUNCTION pg_bulkload(
+CREATE SCHEMA pgbulkload;
+
+CREATE FUNCTION pgbulkload.pg_bulkload(
 	IN options text[],
 	OUT skip bigint,
 	OUT count bigint,

--- a/lib/uninstall_pg_bulkload.sql
+++ b/lib/uninstall_pg_bulkload.sql
@@ -4,6 +4,5 @@
  *    Copyright (c) 2007-2017, NIPPON TELEGRAPH AND TELEPHONE CORPORATION
  */
 
-SET search_path = public;
-
-DROP FUNCTION pg_bulkload(text[]);
+DROP FUNCTION pgbulkload.pg_bulkload(text[]);
+DROP SCHEMA pgbulkload;

--- a/lib/writer_binary.c
+++ b/lib/writer_binary.c
@@ -384,7 +384,7 @@ BinaryWriterSendQuery(BinaryWriter *self, PGconn *conn, char *queueName, char *l
 
 	initStringInfo(&buf);
 	appendStringInfoString(&buf, 
-		"SELECT * FROM pg_bulkload(ARRAY["
+		"SELECT * FROM pgbulkload.pg_bulkload(ARRAY["
 		"'TYPE=TUPLE',"
 		"'INPUT=' || $1,"
 		"'WRITER=BINARY',"

--- a/lib/writer_buffered.c
+++ b/lib/writer_buffered.c
@@ -222,7 +222,7 @@ BufferedWriterSendQuery(BufferedWriter *self, PGconn *conn, char *queueName, cha
 	params[7] = (self->base.truncate ? "true" : "no");
 
 	return PQsendQueryParams(conn,
-		"SELECT * FROM pg_bulkload(ARRAY["
+		"SELECT * FROM pgbulkload.pg_bulkload(ARRAY["
 		"'TYPE=TUPLE',"
 		"'INPUT=' || $1,"
 		"'WRITER=BUFFERED',"

--- a/lib/writer_direct.c
+++ b/lib/writer_direct.c
@@ -435,7 +435,7 @@ DirectWriterSendQuery(DirectWriter *self, PGconn *conn, char *queueName, char *l
 	params[7] = (self->base.truncate ? "true" : "no");
 
 	return PQsendQueryParams(conn,
-		"SELECT * FROM pg_bulkload(ARRAY["
+		"SELECT * FROM pgbulkload.pg_bulkload(ARRAY["
 		"'TYPE=TUPLE',"
 		"'INPUT=' || $1,"
 		"'WRITER=DIRECT',"

--- a/util/pg_timestamp.sql.in
+++ b/util/pg_timestamp.sql.in
@@ -4,12 +4,10 @@
  *    Copyright (c) 2007-2011, NIPPON TELEGRAPH AND TELEPHONE CORPORATION
  */
 
-SET search_path = public;
-
 BEGIN;
 
 -- Register the user defined function
-CREATE FUNCTION pg_timestamp_in(cstring, oid, int4)
+CREATE FUNCTION public.pg_timestamp_in(cstring, oid, int4)
 	RETURNS timestamp
 	LANGUAGE C
 	as 'MODULE_PATHNAME', 'pg_timestamp_in';

--- a/util/uninstall_pg_timestamp.sql
+++ b/util/uninstall_pg_timestamp.sql
@@ -4,14 +4,12 @@
  *    Copyright (c) 2007-2011, NIPPON TELEGRAPH AND TELEPHONE CORPORATION
  */
 
-SET search_path = public;
-
 BEGIN;
 
 UPDATE pg_type
    SET typinput = (SELECT oid FROM pg_proc WHERE proname='timestamp_in')
  WHERE typname='timestamp';
 
-DROP FUNCTION pg_timestamp_in(cstring, oid, int4);
+DROP FUNCTION public.pg_timestamp_in(cstring, oid, int4);
 
 COMMIT;


### PR DESCRIPTION
This patch addresses a vulnerability of CVE-2018-1058(search_path).
The pg_bulkload function uses the pgbulkload schema,
and made to new schema like "pgbulkload".
I have set search_path to " pg_catalog, pg_temp, public" when connecting to pg using pg_bulkload.
And the regression test has passed.