### PR TITLE
Fixed broken library paths on ubuntu packages(#97)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+name: Build_with_ubuntu_packages
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 1 * * SUN"         # only master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        PGVERSION:                # TODO: build with master branch
+          - 13                    # TODO: build with another version
+
+    steps:
+    - name: cat version
+      shell: bash -xe {0}
+      run: |
+         cat /etc/os-release
+         uname -a
+
+    - name: get current branch name
+      shell: bash -xe {0}
+      run: |
+        if [ ${{ github.event_name }} = "pull_request" ]; then
+          echo "BRANCH=${{ github.base_ref }}" >>  $GITHUB_ENV
+        else # push
+          echo "BRANCH=${GITHUB_REF##*/}" >>  $GITHUB_ENV
+        fi
+
+    - name: set build postgresql version
+      shell: bash -xe {0}
+      run: |
+        echo "PGVERSION=${{ matrix.PGVERSION }}" >> $GITHUB_ENV
+
+    - name: download packages for building
+      if: steps.cache-package.outputs.cache-hit != 'true'
+      shell: bash -xe {0}
+      run: |
+        # https://www.postgresql.org/download/linux/ubuntu/
+        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+        sudo apt-get update
+        sudo apt-get -y install           \
+          build-essential                 \
+          libpam-dev                      \
+          libkrb5-dev                     \
+          postgresql-${{ env.PGVERSION }} \
+          postgresql-server-dev-${{ env.PGVERSION }}
+
+    - uses: actions/checkout@v2
+
+    - name: make  # only check if build is success. The tests are skipped because another workflow does so.
+      shell: bash -xe {0}
+      run: make
+
+    - name: check version
+      shell: bash -xe {0}
+      run: bin/pg_bulkload --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - REL_UNDER_PG13_STABLE
   pull_request:
     branches:
       - master
+      - REL_UNDER_PG13_STABLE
   schedule:
     - cron: "0 1 * * SUN"         # only master
 
@@ -14,10 +16,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    strategy:
-      matrix:
-        PGVERSION:                # TODO: build with master branch
-          - 13                    # TODO: build with another version
 
     steps:
     - name: cat version
@@ -38,10 +36,18 @@ jobs:
     - name: set build postgresql version
       shell: bash -xe {0}
       run: |
-        echo "PGVERSION=${{ matrix.PGVERSION }}" >> $GITHUB_ENV
+        declare -A versions=(
+          ["master"]="13"
+          ["REL_UNDER_PG13_STABLE"]="12"
+        )
+        [ -z "${versions[${{ env.BRANCH }}]}" ] && exit 1         # check if the key exists
+        echo "PGVERSION=${versions[${{ env.BRANCH }}]}" >> $GITHUB_ENV
+
+    - name: remove pre-installed postgresql packages
+      shell: bash -xe {0}
+      run: sudo apt-get remove postgresql*
 
     - name: download packages for building
-      if: steps.cache-package.outputs.cache-hit != 'true'
       shell: bash -xe {0}
       run: |
         # https://www.postgresql.org/download/linux/ubuntu/
@@ -52,6 +58,11 @@ jobs:
           build-essential                 \
           libpam-dev                      \
           libkrb5-dev                     \
+          libssl-dev                      \
+          libreadline-dev                 \
+          libselinux-dev                  \
+          libedit-dev                     \
+          zlib1g-dev                      \
           postgresql-${{ env.PGVERSION }} \
           postgresql-server-dev-${{ env.PGVERSION }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,148 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 1 * * SUN"      # only master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        PGVERSION:                # TODO: build with master branch
+          - 13.2                  # TODO: build with another version
+          #- 12.6
+          #- 11.11
+          #- 10.16
+          #- 9.6.21
+          #- 9.5.25
+          #- 9.4.26
+          #- 9.3.25
+    env:
+      CACHE_VERSION: 20210426  # to identify cache version
+
+    steps:
+    - name: cat version
+      shell: bash -xe {0}
+      run: |
+         cat /etc/os-release
+         uname -a
+
+    - name: get current branch name
+      shell: bash -xe {0}
+      run: |
+        if [ ${{ github.event_name }} = "pull_request" ]; then
+          echo "BRANCH=${{ github.base_ref }}" >>  $GITHUB_ENV
+        else # push
+          echo "BRANCH=${GITHUB_REF##*/}" >>  $GITHUB_ENV
+        fi
+
+    - name: set build postgresql version
+      shell: bash -xe {0}
+      run: |
+        echo "PGVERSION=${{ matrix.PGVERSION }}" >> $GITHUB_ENV
+
+    - name: cache builded resources
+      id: cache-postgresql-core
+      uses: actions/cache@v2
+      with:
+        path: "~/pgsql/${{ env.PGVERSION }}"
+        key: ${{ env.PGVERSION }}-${{ env.CACHE_VERSION }}
+
+    - name: build postgresql
+      if: steps.cache-postgresql-core.outputs.cache-hit != 'true'
+      shell: bash -xe {0}
+      run: |
+        # set environment variables
+        export PGHOME=~/pgsql/${{ env.PGVERSION }}
+
+        # install
+        sudo apt-get update -qq
+        sudo apt-get -y install bc libpam-dev libedit-dev
+        wget -q https://ftp.postgresql.org/pub/source/v${{ env.PGVERSION }}/postgresql-${{ env.PGVERSION }}.tar.gz
+        tar xzf postgresql-${{ env.PGVERSION }}.tar.gz
+
+        # TODO: if test with master branch
+        # git clone --single-branch --branch ${{ env.PGVERSION }} \
+        #   https://github.com/postgres/postgres.git ${{ env.PGVERSION }}
+
+        cd postgresql-${{ env.PGVERSION }}
+        ./configure --prefix=$PGHOME --enable-cassert
+
+        gcc -v
+        LOGFILE=~/make.log
+        make -j 4 2>&1 | tee $LOGFILE
+        make install 2>&1 | tee -a $LOGFILE
+
+    - name: show build warning
+      if: steps.cache-postgresql-core.outputs.cache-hit != 'true'
+      shell: bash -xe {0}
+      run: |
+        LOGFILE=~/make.log  # TODO: though I want to remove duplicated vars...
+        grep -C 1 warning $LOGFILE || exit 0     # ok if warning doesn't exists (= status code is 1)
+
+    - name: create database directory
+      shell: bash -xe {0}
+      run: |
+        export PGHOME=~/pgsql/${{ env.PGVERSION }}
+        export PGDATA=~/pgdata/${{ env.PGVERSION }}
+        export ARCHIVEDIR=~/pgdata/arc
+        export PATH=$PGHOME/bin:$PATH:
+
+        mkdir -p $PGDATA
+        initdb --no-locale -D $PGDATA
+        echo "local   all         postgres                          trust" > $PGDATA/pg_hba.conf
+        echo "local   all         all                               trust" >> $PGDATA/pg_hba.conf
+        echo "host    all         all         127.0.0.1/32          trust" >> $PGDATA/pg_hba.conf
+        echo "host    all         all         ::1/128               trust" >> $PGDATA/pg_hba.conf
+        echo "wal_level = hot_standby" >> $PGDATA/postgresql.conf                 # mapped to "replica" from PG9.6
+        echo "archive_mode = on" >> $PGDATA/postgresql.conf
+        echo "archive_command = 'cp %p $ARCHIVEDIR/%f'" >> $PGDATA/postgresql.conf
+        pg_ctl -V
+        pg_ctl -D $PGDATA start
+
+    - name: show postgresql configuration
+      shell: bash -xe {0}
+      run: |
+        export PGHOME=~/pgsql/${{ env.PGVERSION }}
+        export PGDATA=~/pgdata/${{ env.PGVERSION }}
+        export PATH=$PGHOME/bin:$PATH:
+        pg_config --version
+        cat $PGDATA/postgresql.conf
+
+    - uses: actions/checkout@v2
+
+    - name: make install
+      shell: bash -xe {0}
+      run: |
+        export PGHOME=~/pgsql/${{ env.PGVERSION }}
+        export PATH=$PGHOME/bin:$PATH:
+        LOGFILE=~/make.log
+        make install 2>&1 | tee $LOGFILE
+
+    - name: show build warning
+      shell: bash -xe {0}
+      run: |
+        LOGFILE=~/make.log
+        grep -C 1 warning $LOGFILE || exit 0     # ok if warning doesn't exists (= status code is 1)
+
+    - name: make installcheck
+      shell: bash -xe {0}
+      run: |
+        export PGHOME=~/pgsql/${{ env.PGVERSION }}
+        export PATH=$PGHOME/bin:$PATH:
+        make installcheck
+
+    - name: show the result if the regression test failed
+      if: failure()
+      shell: bash -xe {0}
+      run: |
+        cat regression.diffs   \
+         && exit 1     # notify fail

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -30,6 +30,10 @@ include $(makefile_global)
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
+# libs pgport, pgcommon moved somewhere else in some ubuntu version
+# see ticket #97
+PG_LIBS += -L$(shell $(PG_CONFIG) --pkglibdir)
+
 # remove dependency to libxml2 and libxslt
 LIBS := $(filter-out -lxml2, $(LIBS))
 LIBS := $(filter-out -lxslt, $(LIBS))


### PR DESCRIPTION
This patch fix #97. I tested this patch works with the following dockerfile.

``` 
> cat Dockerfile
FROM postgres:11
RUN apt-get update && \
  apt-get install -y \
    git \
    build-essential \
    libpam-dev \
    libssl-dev \
    libreadline-dev \
    libselinux-dev \
    libedit-dev \
    libkrb5-dev \
    zlib1g-dev \
    postgresql-server-dev-11 \
    postgresql-contrib-11
COPY pg_bulkload /pg_bulkload
RUN cd /pg_bulkload && make && make install
CMD ["pg_bulkload", "--version"]
```

This patch refers to pg_repack project's [issue](https://github.com/reorg/pg_repack/issues/179) and [PR](https://github.com/reorg/pg_repack/commit/58e8e60c41b41072d6118237a7d0a2cf7c772af7)