### PR TITLE
Changes for building on mac os

### DIFF
--- a/.github/workflows/build_osx.yml
+++ b/.github/workflows/build_osx.yml
@@ -1,0 +1,50 @@
+name: Build_with_MacOS
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 1 * * SUN"      # only master
+
+jobs:
+  build:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    env:
+      PGVERSION: 13                 # only test for postgresql version 13
+
+    steps:
+    - name: cat osx version
+      shell: bash -xe {0}
+      run: sw_vers
+
+    - name: get current branch name
+      shell: bash -xe {0}
+      run: |
+        if [ ${{ github.event_name }} = "pull_request" ]; then
+          echo "BRANCH=${{ github.base_ref }}" >>  $GITHUB_ENV
+        else # push
+          echo "BRANCH=${GITHUB_REF##*/}" >>  $GITHUB_ENV
+        fi
+
+    - name: download packages for building
+      shell: bash -xe {0}
+      run: |
+        brew update
+        brew install postgresql@${{ env.PGVERSION }}
+        psql --version
+        pg_config
+
+    - uses: actions/checkout@v2
+
+    - name: make  # only check if build is success. The tests are skipped because another workload do so.
+      shell: bash -xe {0}
+      run: make
+
+    - name: check version
+      shell: bash -xe {0}
+      run: bin/pg_bulkload --version

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -168,4 +168,7 @@ subclean:
 
 installcheck: sql/init.sql sql/load_bin.sql sql/load_csv.sql sql/load_function.sql sql/load_filter.sql sql/write_bin.sql
 
-LDFLAGS+=-Wl,--build-id
+UNAME := $(shell uname)
+ifneq ($(UNAME), Darwin)     # osx's ld doesn't support build-id option
+	LDFLAGS+=-Wl,--build-id
+endif

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -70,4 +70,7 @@ clean: subclean
 subclean:
 	rm -f nbtsort.c
 
-LDFLAGS+=-Wl,--build-id
+UNAME := $(shell uname)
+ifneq ($(UNAME), Darwin)     # osx's ld doesn't support build-id option
+	LDFLAGS+=-Wl,--build-id
+endif

--- a/lib/writer_parallel.c
+++ b/lib/writer_parallel.c
@@ -8,6 +8,10 @@
 
 #include "libpq-fe.h"
 
+#ifdef HAVE_SYS_SELECT_H
+#include <sys/select.h>
+#endif
+
 #include "access/heapam.h"
 #include "access/xact.h"
 #include "commands/dbcommands.h"


### PR DESCRIPTION
Some users want to build the pg_bulkload source code on mac os. So, this patch enables them to build it.
But, we need to discuss carefully whether to merge them or not because this project focuses on RHEL.