### PR TITLE
remove the check target because this is not supported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ all install installdirs uninstall distprep clean distclean maintainer-clean:
 	done
 
 # We'd like check operations to run all the subtests before failing.
-check installcheck:
+installcheck:
 	@CHECKERR=0; for dir in $(SUBDIRS); do \
 		$(MAKE) -C $$dir $@ || CHECKERR=$$?; \
 	done; \


### PR DESCRIPTION
To handle the following warning.

```
$ make
Makefile:33: 警告: ターゲット 'check' のためのレシピを置き換えます
/home/ikeda/repos/psql/master/lib/postgresql/pgxs/src/makefiles/pgxs.mk:433: 警告: ターゲット 'check' のための古いレシピは無視されます
```