### PR TITLE
update the github action workflow for new minor versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,12 @@ jobs:
     strategy:
       matrix:
         PGVERSION:                # TODO: build with master branch
-          - 14beta2
-          - 13.2
-          - 12.6
-          - 11.11
-          - 10.16
-          - 9.6.21
+          - 14beta3
+          - 13.4
+          - 12.8
+          - 11.13
+          - 10.18
+          - 9.6.23
           - 9.5.25
     env:
       CACHE_VERSION: 20210426  # to identify cache version


### PR DESCRIPTION
PostgreSQL community released new minor versions and v14 beta3.
https://www.postgresql.org/about/news/postgresql-134-128-1113-1018-9623-and-14-beta-3-released-2277/

After checking, I couldn't find any changes that required the modification of pg_rman.
And, the all tests are passed when using new minor versions.

I think It's better to update the github action workflow to test with new versions.