### PR TITLE
update test version for 14rc1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         PGVERSION:                # TODO: build with master branch
-          - 14beta3
+          - 14rc1
           - 13.4
           - 12.8
           - 11.13


### PR DESCRIPTION
Update the test version for 14 RC1.

I checked the release notes and I think we don't need to update the codes.
https://www.postgresql.org/about/news/postgresql-14-rc-1-released-2309/