### PR TITLE
Fixed when function with variadic arguments did not work correctly (#…

### DIFF
--- a/lib/parser_function.c
+++ b/lib/parser_function.c
@@ -321,13 +321,13 @@ FunctionParserInit(FunctionParser *self, Checker *checker, const char *infile, T
 	ReleaseSysCache(ftup);
 
 #if PG_VERSION_NUM >= 120000
-	InitFunctionCallInfoData(*self->fcinfo, &self->flinfo, nargs,
+	InitFunctionCallInfoData(*self->fcinfo, &self->flinfo, self->flinfo.fn_nargs,
 		collation, NULL, (Node *) &self->rsinfo);
 #elif PG_VERSION_NUM >= 90100
-	InitFunctionCallInfoData(self->fcinfo, &self->flinfo, nargs,
+	InitFunctionCallInfoData(self->fcinfo, &self->flinfo, self->flinfo.fn_nargs,
 		collation, NULL, (Node *) &self->rsinfo);
 #else
-	InitFunctionCallInfoData(self->fcinfo, &self->flinfo, nargs,
+	InitFunctionCallInfoData(self->fcinfo, &self->flinfo, self->flinfo.fn_nargs,
 		NULL, (Node *) &self->rsinfo);
 #endif
 


### PR DESCRIPTION
…123)

If a function has variadic arguments, postgres may crash when the wrong number of arguments may be passed to postgres.