### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/pg_bulkload.html
+++ b/docs/pg_bulkload.html
@@ -103,7 +103,7 @@ pg_bulkload() function will be installed during pg_bulkload installation.
 </p>
 
 <p>
-You can use pg_bulklad by the following three steps:
+You can use pg_bulkload by the following three steps:
 </p>
 <ol>
 <li>Edit control file "<a href="sample_csv.ctl">sample_csv.ctl</a>" or "<a href="sample_bin.ctl">sample_bin.ctl</a>" that includes settigs for data loading. You can specify table name, absolute path for input file, description of the input file, and so on.

--- a/docs/pg_bulkload.html
+++ b/docs/pg_bulkload.html
@@ -106,7 +106,7 @@ pg_bulkload() function will be installed during pg_bulkload installation.
 You can use pg_bulkload by the following three steps:
 </p>
 <ol>
-<li>Edit control file "<a href="sample_csv.ctl">sample_csv.ctl</a>" or "<a href="sample_bin.ctl">sample_bin.ctl</a>" that includes settigs for data loading. You can specify table name, absolute path for input file, description of the input file, and so on.
+<li>Edit control file "<a href="sample_csv.ctl">sample_csv.ctl</a>" or "<a href="sample_bin.ctl">sample_bin.ctl</a>" that includes settings for data loading. You can specify table name, absolute path for input file, description of the input file, and so on.
 
 <li>Assume there is a directory <code>$PGDATA/pg_bulkload</code>, in that load status files are created.
 


### PR DESCRIPTION
Rename 'pg_bulklad' to 'pg_bulkload' and 'settngs' to 'settings'