### PR TITLE
Add notes the user must be a superuser

### DIFF
--- a/docs/pg_bulkload-ja.html
+++ b/docs/pg_bulkload-ja.html
@@ -185,7 +185,7 @@ NOTICE: BULK LOAD END
 
 <dt>-U USERNAME<br />
 --username=USERNAME</dt>
-<dd>接続するユーザ名を指定します。</dd>
+<dd>接続するユーザ名を指定します。pg_bulkloadの実行ユーザは、スーパユーザ権限が必要です。</dd>
 
 <dt>-W<br />
 --password</dt>

--- a/docs/pg_bulkload.html
+++ b/docs/pg_bulkload.html
@@ -204,7 +204,7 @@ If that is not set, the user name specified for the connection is used.
 
 <dt>-U username<br />
 --username username</dt>
-<dd>User name to connect as. </dd>
+<dd>User name to connect as. The user must be a superuser for pg_bulkload execution.</dd>
 
 <dt>-W<br />--password</dt>
 <dd>Force pg_bulkload to prompt for a password before connecting to a database.</dd>


### PR DESCRIPTION
pg_bulkload expects that the user is a superuser.

```
$ pg_bulkload sample_csv.ctl --username test --dbname test
NOTICE: BULK LOAD START
ERROR: query failed: ERROR:  must be superuser to use pg_bulkload
DETAIL: query was: SELECT * FROM pgbulkload.pg_bulkload($1)
```