### PR TITLE
add tiebreaker in btree mergeload

### DIFF
--- a/lib/pg_btree.c
+++ b/lib/pg_btree.c
@@ -605,6 +605,14 @@ _bt_mergeload(Spooler *self, BTWriteState *wstate, BTSpool *btspool, BTReader *b
 			}
 			else if (compare > 0)
 				load1 = false;
+
+			if (compare == 0)
+			{
+				compare = ItemPointerCompare(&itup->t_tid, &itup2->t_tid);
+					Assert(compare != 0);
+					if (compare > 0)
+						load1 = false;
+			}
 		}
 		else
 			load1 = false;


### PR DESCRIPTION
If key values are equal, nbtree treat ItemPointer as tiebreaker to ensure all keys are physically unique. 