### PR TITLE
[WIP] Add scripts for building RPMs and creating release draft

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,0 +1,75 @@
+ARG RHEL_VERSION
+FROM rockylinux:${RHEL_VERSION}
+
+ARG RHEL_VERSION
+ARG PG_VERSION
+ARG PG_BULKLOAD_VERSION
+
+ENV PATH /usr/pgsql-${PG_VERSION}/bin:$PATH
+ENV PGDATA /var/lib/pgsql/${PG_VERSION}/data
+
+
+################################################################################
+#
+# Prerequisite
+#
+################################################################################
+
+# Install packages for build
+RUN dnf update -y
+RUN dnf install -y \
+        clang gcc git krb5-devel libselinux-devel libzstd-devel lz4-devel make \
+        openssl-devel pam-devel readline-devel rpmdevtools zlib-devel
+
+# Install PostgreSQL
+RUN if [ "${RHEL_VERSION}" = "8" ]; then \
+        dnf install -y --enablerepo=powertools perl-IPC-Run; \
+    else \
+        dnf install -y --enablerepo=crb perl-IPC-Run; \
+    fi
+RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-${RHEL_VERSION}-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+RUN dnf -qy module disable postgresql
+RUN dnf install -y \
+        postgresql${PG_VERSION}-server \
+        postgresql${PG_VERSION}-devel \
+        postgresql${PG_VERSION}-llvmjit
+
+
+################################################################################
+#
+# Build RPMs
+#
+################################################################################
+
+# Build by postgres user
+USER postgres
+WORKDIR /var/lib/pgsql/
+
+# Deploy the files required for the build
+RUN rpmdev-setuptree
+RUN git clone https://github.com/ossc-db/pg_bulkload.git
+RUN cp -a pg_bulkload/SPECS/pg_bulkload-pg${PG_VERSION}.spec rpmbuild/SPECS
+RUN cd pg_bulkload && \
+    git archive VERSION${PG_BULKLOAD_VERSION//./_} \
+        --format=tar.gz \
+        --prefix=pg_bulkload-${PG_BULKLOAD_VERSION}/ \
+        --output=../rpmbuild/SOURCES/pg_bulkload-${PG_BULKLOAD_VERSION}.tar.gz
+
+# Build RPMs
+RUN rpmbuild rpmbuild/SPECS/pg_bulkload-pg${PG_VERSION}.spec \
+        -bb --define="dist .pg${PG_VERSION}.rhel${RHEL_VERSION}"
+
+
+###############################################################q#################
+#
+# Run regression tests
+#
+################################################################################
+
+USER root
+RUN rpm -ivh /var/lib/pgsql/rpmbuild/RPMS/x86_64/*
+
+USER postgres
+RUN initdb --no-locale -E UTF8  && \
+    pg_ctl -w start && \
+    make -C pg_bulkload installcheck

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -60,7 +60,7 @@ RUN rpmbuild rpmbuild/SPECS/pg_bulkload-pg${PG_VERSION}.spec \
         -bb --define="dist .pg${PG_VERSION}.rhel${RHEL_VERSION}"
 
 
-###############################################################q#################
+################################################################################
 #
 # Run regression tests
 #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Build RPMs and upload its to release draft
+
+on:
+  push:
+    tags:
+      - 'VERSION*'
+
+jobs:
+  build_rpms:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        RHEL_VERSION: ["8", "9"]
+        PG_VERSION: ["13", "14", "15", "16"]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Build PostgreSQL ${{ matrix.PG_VERSION }} RPMs for RHEL ${{ matrix.RHEL_VERSION }}
+      run: |
+        export PG_BULKLOAD_VERSION=$(echo "${GITHUB_REF_NAME#VERSION}" | sed 's/_/./g')
+        docker build .github/workflows/ -t pg_bulkload \
+          --build-arg RHEL_VERSION=${{ matrix.RHEL_VERSION }} \
+          --build-arg PG_VERSION=${{ matrix.PG_VERSION }} \
+          --build-arg PG_BULKLOAD_VERSION=${PG_BULKLOAD_VERSION}
+        container_id=$(docker create pg_bulkload)
+        docker cp $container_id:/var/lib/pgsql/rpmbuild/RPMS/x86_64 ./RPMS
+
+    - name: Create release draft and upload the RPMs
+      uses: softprops/action-gh-release@v2
+      with:
+        name: Release draft
+        draft: true
+        files: ./RPMS/*.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         RHEL_VERSION: ["8", "9"]
-        PG_VERSION: ["13", "14", "15", "16"]
+        PG_VERSION: ["13", "14", "15", "16", "17"]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Build RPMs when tags are pushed and attach them to the draft release.
- This PR is in progress.
  - When PostgreSQL 17 is released, we need to add ‘17’ to PG_VERSION and check that it works properly.

## How to test this PR
1. Fork pg_bulkload to your repository and execute below commands.
```
git clone https://github.com/<username>/pg_bulkload.git
cd pg_bulkload
git remote add remote https://github.com/ossc-db/pg_bulkload
git fetch remote pull/164/head:add-auto-rpm-build
git switch add-auto-rpm-build
git commit -m test --allow-empty
git tag VERSION3_1_21 -f
git push origin VERSION3_1_21 -f
```

2. Access  https://github.com/username/pg_bulkload/actions
3. Sometimes the script hangs. When this happens, press ‘Cancel workflow’ and re-run with ‘Re-run failed jobs’.
4. Check release draft at https://github.com/username/pg_bulkload/releases