### PR TITLE
Add support for RHEL 10 and some improvements

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,12 +1,12 @@
 ARG RHEL_VERSION
-FROM rockylinux:${RHEL_VERSION}
+FROM rockylinux/rockylinux:${RHEL_VERSION:-10}
 
 ARG RHEL_VERSION
 ARG PG_VERSION
 ARG PG_BULKLOAD_VERSION
 
-ENV PATH /usr/pgsql-${PG_VERSION}/bin:$PATH
-ENV PGDATA /var/lib/pgsql/${PG_VERSION}/data
+ENV PATH=/usr/pgsql-${PG_VERSION}/bin:$PATH
+ENV PGDATA=/var/lib/pgsql/${PG_VERSION}/data
 
 
 ################################################################################
@@ -16,8 +16,9 @@ ENV PGDATA /var/lib/pgsql/${PG_VERSION}/data
 ################################################################################
 
 # Install packages for build
-RUN dnf update -y
-RUN dnf install -y \
+RUN sed -i -e '/^mirrorlist=/s/^/#/' -e '/^#baseurl=/s/^#//' /etc/yum.repos.d/*.repo && \
+    dnf update -y && \
+    dnf install -y \
         clang gcc git krb5-devel libselinux-devel libzstd-devel lz4-devel make \
         openssl-devel pam-devel readline-devel rpmdevtools zlib-devel
 
@@ -28,7 +29,9 @@ RUN if [ "${RHEL_VERSION}" = "8" ]; then \
         dnf install -y --enablerepo=crb perl-IPC-Run; \
     fi
 RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-${RHEL_VERSION}-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-RUN dnf -qy module disable postgresql
+RUN if [ "${RHEL_VERSION}" = "8" ] || ["${RHEL_VERSION}" = "9" ]; then \
+        dnf -qy module disable postgresql; \
+    fi
 RUN dnf install -y \
         postgresql${PG_VERSION}-server \
         postgresql${PG_VERSION}-devel \
@@ -56,7 +59,7 @@ RUN cd pg_bulkload && \
         --output=../rpmbuild/SOURCES/pg_bulkload-${PG_BULKLOAD_VERSION}.tar.gz
 
 # Build RPMs
-RUN rpmbuild rpmbuild/SPECS/pg_bulkload-pg${PG_VERSION}.spec \
+RUN QA_RPATHS=0x0002 rpmbuild rpmbuild/SPECS/pg_bulkload-pg${PG_VERSION}.spec \
         -bb --define="dist .pg${PG_VERSION}.rhel${RHEL_VERSION}"
 
 

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -29,7 +29,7 @@ RUN if [ "${RHEL_VERSION}" = "8" ]; then \
         dnf install -y --enablerepo=crb perl-IPC-Run; \
     fi
 RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-${RHEL_VERSION}-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-RUN if [ "${RHEL_VERSION}" = "8" ] || ["${RHEL_VERSION}" = "9" ]; then \
+RUN if [ "${RHEL_VERSION}" = "8" ] || [ "${RHEL_VERSION}" = "9" ]; then \
         dnf -qy module disable postgresql; \
     fi
 RUN dnf install -y \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,9 @@ jobs:
     permissions:
       contents: write
     strategy:
+      fail-fast: false
       matrix:
-        RHEL_VERSION: ["8", "9"]
+        RHEL_VERSION: ["8", "9", "10"]
         PG_VERSION: ["13", "14", "15", "16", "17"]
     steps:
     - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: cache builded resources
       id: cache-postgresql-core
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: "~/pgsql/${{ env.PGVERSION }}"
         key: ${{ env.PGVERSION }}-${{ env.CACHE_VERSION }}


### PR DESCRIPTION
Fix a rpmbuild error by ignoring RPATH (`QA_RPATHS=0x0002`).

Fix Dockerfile warnings by using `ENV=VALUE` style insead of `ENV VALUE` style and set default value in `RHEL_VERSION`.

Fix a Rocky Linux repository.

Fix not to use mirror repository in Rocky Linux for stability.