### PR TITLE
Fix PARSE_BADFILE default filename format in documentation

### DIFF
--- a/docs/pg_bulkload-ja.html
+++ b/docs/pg_bulkload-ja.html
@@ -438,7 +438,7 @@ ON_DUPLICATE_KEEP を「WRITER=BINARY」と同時に指定した場合はエラ�
 パース処理、エンコーディングチェック、エンコーディング変換、FILTER 関数の実行、CHECK 制約適用、非 NULL 制約適用およびデータ型変換時に見つかった不良レコードを記録するBADファイルのパスを指定します。
 このファイルには、入力ファイルと同じ形式(CSVまたは固定長)で記録されます。
 相対パスで指定した場合の扱いは <a href="#INPUT">INPUT</a> と同じです。
-デフォルトは $PGDATA/pg_bulkload/&lt;タイムスタンプ&gt;_&lt;DB名&gt;_&lt;スキーマ名&gt;_&lt;テーブル名&gt;.bad.&lt;入力ファイルの拡張子&gt; です。
+デフォルトは $PGDATA/pg_bulkload/&lt;タイムスタンプ&gt;_&lt;DB名&gt;_&lt;スキーマ名&gt;_&lt;テーブル名&gt;.prs.&lt;入力ファイルの拡張子&gt; です。
 </dd>
 
 <dt id="DUPLICATE_BADFILE">DUPLICATE_BADFILE = path</dt>

--- a/docs/pg_bulkload.html
+++ b/docs/pg_bulkload.html
@@ -460,7 +460,7 @@ A path to the BAD file logging invalid records which caused an error during pars
 encoding conversion, FILTER function, CHECK constraint checks, NOT NULL checks, or data type conversion.
 The format of the file is same as the input source file.
 If specified by a relative path, it is treated as same as <a href="#INPUT">INPUT</a>.
-The default is $PGDATA/pg_bulkload/&lt;<i>timestamp</i>&gt;_&lt;<i>dbname</i>&gt;_&lt;<i>schema</i>&gt;_&lt;<i>table</i>&gt;.bad.&lt;<i>extension-of-infile</i>&gt;.
+The default is $PGDATA/pg_bulkload/&lt;<i>timestamp</i>&gt;_&lt;<i>dbname</i>&gt;_&lt;<i>schema</i>&gt;_&lt;<i>table</i>&gt;.prs.&lt;<i>extension-of-infile</i>&gt;.
 </dd>
 
 <dt id="DUPLICATE_BADFILE">DUPLICATE_BADFILE = path</dt>


### PR DESCRIPTION
I found a discrepancy between the official pg_bulkload documentation and the actual behavior regarding the default output filename of PARSE_BADFILE. 

In my environment (PostgreSQL 18.3 + pg_bulkload 3.1.23), the generated filename uses: <timestamp>_<dbname>_<schema>_<table>.prs.<extension-of-infile> 
However, the official documentation states: 
<timestamp>_<dbname>_<schema>_<table>.bad.<extension-of-infile> 

This patch updates both the Japanese and English documentation to match the actual behavior.